### PR TITLE
Refine binary search embed guidance

### DIFF
--- a/src/discord/commands.ts
+++ b/src/discord/commands.ts
@@ -10,6 +10,7 @@ import { LagCommand } from "@/discord/commands/lag.ts";
 import { InfiniteGlyphsCommand } from "@/discord/commands/infinite-glyphs.ts";
 import { PinInThreadCommand } from "@/discord/commands/pin-in-thread.ts";
 import { LmgtfyCommand } from "@/discord/commands/lmgtfy.ts";
+import { BinarySearchCommand } from "@/discord/commands/binary-search.ts";
 
 export default [
   new IframesCommand(),
@@ -23,4 +24,5 @@ export default [
   new InfiniteGlyphsCommand(),
   new PinInThreadCommand(),
   new LmgtfyCommand(),
+  new BinarySearchCommand(),
 ] as Command[];

--- a/src/discord/commands/binary-search.ts
+++ b/src/discord/commands/binary-search.ts
@@ -1,0 +1,29 @@
+import { APIEmbedField } from "npm:@buape/carbon";
+import { BaseEmbedCommand } from "@/discord/abstracts/embed-command.ts";
+
+const lines = [
+  "Binary searching your mods lets you find the offending mod faster than disabling them one by one.",
+  "1. Make a backup of your instance so you can restore it later.",
+  "2. Disable or move half of your mods and then reproduce the issue.",
+  "3. If the issue still happens, the broken mod is in the enabled half. Otherwise, it's in the disabled half.",
+  "4. Repeat the process with the half that still has the issue until you narrow it down to a single mod.",
+];
+
+export class BinarySearchCommand extends BaseEmbedCommand {
+  name = "binary-search";
+  description = "How to debug mod issues with a binary search";
+  title = ":mag: Binary Search for Mod Issues";
+  lines = lines;
+  extraFields: APIEmbedField[] = [
+    {
+      name: "Keep dependencies together",
+      value:
+        "If a mod depends on others, move the whole group together so you don't create new errors while testing.",
+    },
+    {
+      name: "How to disable mods quickly?",
+      value:
+        "Move the inactive half into a folder like `disabled-mods` so you can toggle groups without deleting anything.",
+    },
+  ];
+}


### PR DESCRIPTION
## Summary
- update the embed tips to recommend moving mods into a `disabled-mods` folder when testing
- remove the unnecessary documentation reminder field from the binary search embed

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_690ce5feae90832489bd8327c1e097bc